### PR TITLE
Send client id header to egghead api requests

### DIFF
--- a/src/hooks/use-bundle-progress.tsx
+++ b/src/hooks/use-bundle-progress.tsx
@@ -4,10 +4,10 @@ import find from 'lodash/find'
 import {useLocalStorage} from 'react-use'
 import {useViewer} from 'contexts/viewer-context'
 import useSWR from 'swr'
-import Axios from 'axios'
+import axios from 'utils/axios'
 
 const fetcher = (url: string, token: string) => {
-  return Axios.get(
+  return axios.get(
     `${process.env.NEXT_PUBLIC_AUTH_DOMAIN}/api/v1/bundle/${url}/progress_v2?expand=section_resources`,
     {headers: {Authorization: `Bearer ${token}`}},
   )

--- a/src/hooks/use-commerce-machine.tsx
+++ b/src/hooks/use-commerce-machine.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import axios from 'axios'
+import axios from 'utils/axios'
 import get from 'lodash/get'
 import noop from 'lodash/noop'
 import pickBy from 'lodash/pickBy'

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,13 +1,11 @@
 import OAuthClient from 'client-oauth2'
 import {track, identify} from './analytics'
-import axios from 'axios'
+import http from 'utils/axios'
 import get from 'lodash/get'
-import cookie from './cookies'
+import cookie from 'utils/cookies'
 import * as serverCookie from 'cookie'
 import getAccessTokenFromCookie from './get-access-token-from-cookie'
 import {CIO_KEY} from '../hooks/use-cio'
-
-const http = axios.create()
 
 export const AUTH_DOMAIN = process.env.NEXT_PUBLIC_AUTH_DOMAIN
 const AUTH_CLIENT_ID = process.env.NEXT_PUBLIC_CLIENT_ID

--- a/src/utils/axios.ts
+++ b/src/utils/axios.ts
@@ -1,8 +1,22 @@
 import axios from 'axios'
+import {ACCESS_TOKEN_KEY} from './auth'
 
 axios.interceptors.request.use(
   function (config: any) {
-    const headers = {...config.headers}
+    const authToken =
+      typeof localStorage !== 'undefined'
+        ? localStorage.getItem(ACCESS_TOKEN_KEY)
+        : null
+    const defaultHeaders = authToken
+      ? {
+          Authorization: `Bearer ${authToken}`,
+          'X-SITE-CLIENT': process.env.CLIENT_ID,
+        }
+      : {'X-SITE-CLIENT': process.env.CLIENT_ID}
+    const headers = {
+      ...defaultHeaders,
+      ...config.headers,
+    }
 
     return {...config, headers}
   },


### PR DESCRIPTION
did the same thing as @theianjones did for ER: https://github.com/eggheadio/epic-react-gatsby/pull/241

⚠️ I haven't tested this properly yet and rather blindly copied those changes over.

<img src="https://media.giphy.com/media/26tP3M3i03hoIYL6M/giphy.gif" width="350">

